### PR TITLE
Forward onBlur event

### DIFF
--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -418,6 +418,7 @@ Custom property | Description | Default
     _onBlur: function() {
       if (!this._closeOnBlurIsPrevented) {
         this.close();
+        this.fire("blur");
       }
     },
 


### PR DESCRIPTION
Useful for in-place editing,  we need to onBlur event to be able to replace the combobox by a simple span once we are done editing
